### PR TITLE
Flex conf

### DIFF
--- a/notebook/use_guide.clj
+++ b/notebook/use_guide.clj
@@ -91,7 +91,9 @@ Playwright: This is a synopsis for the above play:
 (def synopsis
   (gen/complete-template
     synopsis-template
-    {:title "Mr. X" :genre "crime"}))
+    {:title "Mr. X" :genre "crime"}
+    {:api-key "sk-xxxxx"}
+   ))
 
 ;; #### Full *Bosquet* produced text
 ^{::clerk/visibility {:code :hide}}

--- a/notebook/use_guide.clj
+++ b/notebook/use_guide.clj
@@ -4,6 +4,13 @@
     [bosquet.generator :as gen]
     [nextjournal.clerk :as clerk]))
 
+(comment
+  (clerk/serve! {})
+  (clerk/show! "notebook/use_guide.clj")
+  )
+
+
+
 ;; # Bosquet Tutorial
 ;;
 ;; This notebook will demonstrate the following things:
@@ -11,6 +18,24 @@
 ;; - resolve *dependencies* between prompts
 ;; - produce AI *completions*.
 ;;
+;; ## Setup models
+;; This notebook will showcase how to use 2 model configurations at the same time
+;; They could be both the same as well
+
+;; OpenAI model
+(def open-ai-config
+  {:impl :openai
+   :api-key "xxxxx"})
+
+
+;; Azure OpenAI model
+(def azure-open-ai-config
+  {:impl :azure
+   :model "yyyy"      ;; deployment name
+   :api-key "xxxx"
+   :api-endpoint "https://xxxxxxx.openai.azure.com/"})
+
+
 ;; ## A simple single template case
 ;;
 ;; Let's say we want to generate a synopsis of the play, based only on the `title` and `genre` we want this play to be in.
@@ -90,10 +115,9 @@ Playwright: This is a synopsis for the above play:
 ;; The *second* member of the tuple will contain only the AI-completed part.
 (def synopsis
   (gen/complete-template
-    synopsis-template
-    {:title "Mr. X" :genre "crime"}
-    {:api-key "sk-xxxxx"}
-   ))
+   synopsis-template
+   {:title "Mr. X" :genre "crime"}
+   {:llm-generate azure-open-ai-config}))
 
 ;; #### Full *Bosquet* produced text
 ^{::clerk/visibility {:code :hide}}
@@ -138,7 +162,11 @@ Review from a New York Times play critic of the above play:
 
 (def review (gen/complete play-review
                           {:title "Mr. X" :genre "crime"}
-                          [:synopsis :evrything]))
+                          [:synopsis :evrything]
+                          
+                          {:synopsis { :llm-generate open-ai-config}
+                           :evrything {:llm-generate azure-open-ai-config}}
+                          ))
 
 ;; ### Fully generated review
 ^{::clerk/visibility {:code :hide}}
@@ -183,7 +211,9 @@ Sentiments:
     "The biggest disappointment of my life came a year ago."])
 
 (def sentiments (gen/complete-template sentimental
-                                       {:text-type "tweets" :tweets tweets}))
+                                       {:text-type "tweets" :tweets tweets}
+                                       {:llm-generate azure-open-ai-config}
+                                       ))
 
 ;; Generation results in the same order as `tweets`
 ^{::clerk/visibility {:code :hide}}

--- a/src/bosquet/openai.clj
+++ b/src/bosquet/openai.clj
@@ -27,7 +27,6 @@
 (defn- create-completion
   "Create completion (not chat) for `prompt` based on model `params` and invocation `opts`"
   [prompt params opts]
-  (println :create-completion params opts)
   (-> (api/create-completion
         (assoc params :prompt prompt) opts)
     :choices first :text))
@@ -70,4 +69,7 @@
 (comment
   (complete "What is your name?" {:max-tokens 10 :model cgpt})
   (complete "What is your name?" {:max-tokens 10})
-  (complete "1 + 10 =" {:model "testtextdavanci003" :impl :azure}))
+  (complete "1 + 10 =" {:model "text-davinci-003"
+                        :impl :azure
+                        :api-key "xxxx"
+                        :api-endpoint "https://xxxxxx.openai.azure.com/"}))

--- a/src/bosquet/template/tag.clj
+++ b/src/bosquet/template/tag.clj
@@ -12,5 +12,8 @@
 
 (defn add-tags []
   (parser/add-tag! :llm-generate
-    (fn [args {pretext :selmer/preceding-text}]
-      (openai/complete pretext (args->map args)))))
+    (fn [args context]
+      (openai/complete (:selmer/preceding-text context) 
+                       (merge 
+                        (args->map args)
+                        (:model-opts context))))))

--- a/src/bosquet/template/tag.clj
+++ b/src/bosquet/template/tag.clj
@@ -16,4 +16,6 @@
       (openai/complete (:selmer/preceding-text context) 
                        (merge 
                         (args->map args)
-                        (:model-opts context))))))
+                        (get-in context [:opts (-> context :the-key) :llm-generate])
+                        
+                        )))))


### PR DESCRIPTION
In this PR I "moved" the configuration of the model "up" to the function "gen/copmplete-template" and  "complete".
(so it merges the  opts from inside the prompt definition and the external opts), external overrides
This has in my view 2 advantages:

- bosque does not need to decide / assume how the user of bosquet manages his secret keys
- a bosque prompt definition does not need to specify any model parameter, so this an be done at "usage time".
  and it can be overriden from the prompt definition user (without touching teh prompt definition)
  (this should make the prompt definition completely model agnostic, so allow to use the same prompt definition with any model
  
I fixed as well the Azure  OpenAI issue. (#9 ) Know the code works again with OpenAI and Azure OpenAI, provided that the correct model options are given to "complete-template"    (or a specified inside the template)