### PR TITLE
allow fn as :impl

### DIFF
--- a/notebook/use_guide.clj
+++ b/notebook/use_guide.clj
@@ -1,8 +1,10 @@
 ^{:nextjournal.clerk/visibility {:code :hide}}
 (ns use-guide
   (:require
-    [bosquet.generator :as gen]
-    [nextjournal.clerk :as clerk]))
+   [bosquet.complete]
+   [bosquet.generator :as gen]
+   [nextjournal.clerk :as clerk]
+   [bosquet.complete :as complete]))
 
 (comment
   (clerk/serve! {})
@@ -30,7 +32,7 @@
 
 ;; Azure OpenAI model
 (def azure-open-ai-config
-  {:impl :azure
+  {:impl bosquet.complete/complete-azure-openai
    :model "yyyy"      ;; deployment name
    :api-key "xxxx"
    :api-endpoint "https://xxxxxxx.openai.azure.com/"})

--- a/notebook/use_guide.clj
+++ b/notebook/use_guide.clj
@@ -4,7 +4,7 @@
    [bosquet.complete]
    [bosquet.generator :as gen]
    [nextjournal.clerk :as clerk]
-   [bosquet.complete :as complete]))
+   [bosquet.openai :as openai]))
 
 (comment
   (clerk/serve! {})
@@ -32,7 +32,7 @@
 
 ;; Azure OpenAI model
 (def azure-open-ai-config
-  {:impl bosquet.complete/complete-azure-openai
+  {:impl openai/complete-azure-openai
    :model "yyyy"      ;; deployment name
    :api-key "xxxx"
    :api-endpoint "https://xxxxxxx.openai.azure.com/"})

--- a/src/bosquet/complete.clj
+++ b/src/bosquet/complete.clj
@@ -2,18 +2,13 @@
   (:require [bosquet.openai :as openai]
             [bosquet.complete :as complete]))
 
-(defn complete-openai [prompt params]
-  (openai/complete prompt (assoc params :impl :openai)))
-
-(defn complete-azure-openai [prompt params]
-  (openai/complete prompt (assoc params :impl :azure)))
 
 (defn complete [prompt params]
   (let [impl (:impl params)
         complete-fn 
         (cond 
-          (= :azure impl)  complete-azure-openai
-          (= :openai impl) complete-openai
+          (= :azure impl)  openai/complete-azure-openai
+          (= :openai impl) openai/complete-openai
           (fn? impl) impl)
         ]
   (complete-fn prompt params))

--- a/src/bosquet/complete.clj
+++ b/src/bosquet/complete.clj
@@ -1,0 +1,21 @@
+(ns bosquet.complete
+  (:require [bosquet.openai :as openai]
+            [bosquet.complete :as complete]))
+
+(defn complete-openai [prompt params]
+  (openai/complete prompt (assoc params :impl :openai)))
+
+(defn complete-azure-openai [prompt params]
+  (openai/complete prompt (assoc params :impl :azure)))
+
+(defn complete [prompt params]
+  (let [impl (:impl params)
+        complete-fn 
+        (cond 
+          (= :azure impl)  complete-azure-openai
+          (= :openai impl) complete-openai
+          (fn? impl) impl)
+        ]
+  (complete-fn prompt params))
+  )
+

--- a/src/bosquet/openai.clj
+++ b/src/bosquet/openai.clj
@@ -66,6 +66,13 @@
        (create-chat prompt params opts)
        (create-completion prompt params opts)))))
 
+(defn complete-openai [prompt params]
+  (complete prompt (assoc params :impl :openai)))
+
+(defn complete-azure-openai [prompt params]
+  (complete prompt (assoc params :impl :azure)))
+
+
 (comment
   (complete "What is your name?" {:max-tokens 10 :model cgpt})
   (complete "What is your name?" {:max-tokens 10})

--- a/src/bosquet/template/tag.clj
+++ b/src/bosquet/template/tag.clj
@@ -1,6 +1,6 @@
 (ns bosquet.template.tag
   (:require
-    [bosquet.openai :as openai]
+    [bosquet.complete :as complete]
     [clojure.string :as string]
     [selmer.parser :as parser]))
 
@@ -13,7 +13,7 @@
 (defn add-tags []
   (parser/add-tag! :llm-generate
     (fn [args context]
-      (openai/complete (:selmer/preceding-text context) 
+      (complete/complete (:selmer/preceding-text context) 
                        (merge 
                         (args->map args)
                         (get-in context [:opts (-> context :the-key) :llm-generate])


### PR DESCRIPTION
This PR allows to provide a fn for :impl (additionally to the kewyords)

It fixes #8  and is the base for fixing #16 