### PR TITLE
allow caching calls to `complete`

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,9 @@
            http-kit/http-kit               {:mvn/version "2.6.0"}
            metosin/jsonista                {:mvn/version "0.3.7"}
            com.taoensso/encore             {:mvn/version "3.59.0"}
-           io.aviso/pretty                 {:mvn/version "1.4.3"}}
+           io.aviso/pretty                 {:mvn/version "1.4.3"}
+           org.clojure/core.cache          {:mvn/version "1.0.217"}
+           }
  :aliases {:dev      {:extra-paths ["dev" "notebook"]}
            :neil     {:project {:name    io.github.zmedelis/bosquet
                                 :version "0.3.0"}}

--- a/src/bosquet/complete.clj
+++ b/src/bosquet/complete.clj
@@ -1,16 +1,37 @@
 (ns bosquet.complete
   (:require [bosquet.openai :as openai]
-            [bosquet.complete :as complete]))
+            [bosquet.complete :as complete]
+            [clojure.core.cache.wrapped :as cache]
+            [clojure.core :as core]
+            ))
 
+(defn complete-with-cache [prompt params cache complete-fn]
+  (cache/lookup-or-miss
+   cache
+   {:prompt prompt
+    :params (dissoc params :cache)}
+   (fn [item]
+     (println :item item)
+     (complete-fn
+      (:prompt item)
+      (:params item)))))
+ 
+(defn atom? [a] (= (type a) clojure.lang.Atom))
+
+;; lookup-or-miss works with an atom of a cache
+(defn ensure-atom [x]
+  (if (atom? x) x (atom x)))
 
 (defn complete [prompt params]
   (let [impl (:impl params)
-        complete-fn 
-        (cond 
+        complete-fn
+        (cond
           (= :azure impl)  openai/complete-azure-openai
           (= :openai impl) openai/complete-openai
-          (fn? impl) impl)
-        ]
-  (complete-fn prompt params))
-  )
+          (fn? impl) impl)]
+
+    (if-let [cache (:cache params)]
+      (complete-with-cache prompt params (ensure-atom cache) complete-fn)
+      (complete-fn prompt params))))
+
 


### PR DESCRIPTION
This PR allows to cache the calls to "complete".
It is optional and gets configured by adding a implementation of a `clojure.core.cache` in the params like this:

```clojure
(def azure-open-ai-config
    {:model "text-davinci-003"
     :impl openai/complete-azure-openai
     :cache  (clojure.core.cache.wrapped/fifo-cache-factory {} :threshold 1)
     :api-key "xxxx"
     :api-endpoint "https://yyyyy.openai.azure.com/"})

```

The code depends on PR #17  and would then fix #11 