### PR TITLE
alternative Azure exception handling , keep ex-info

### DIFF
--- a/src/bosquet/llm/openai.clj
+++ b/src/bosquet/llm/openai.clj
@@ -77,12 +77,12 @@
        (catch Exception e
          (throw
           (ex-info "OpenAI API error"
-            (or
-                (-> e ex-data :body
-                    (j/read-value j/keyword-keys-object-mapper)
-                    :error)
-                ;; Azure has different error data structure
-                {:message (.getMessage e)}))))))))
+                   (or
+                    (-> e ex-data :body
+                        (j/read-value j/keyword-keys-object-mapper)
+                        :error)
+                    ;; Azure has different error data structure
+                    (ex-data e)))))))))
 
 (defn chat-completion
   [messages opts]


### PR DESCRIPTION
Not sure, this is better.
It keeps the exception root case in a map:

```

1. Unhandled clojure.lang.ExceptionInfo
   OpenAI API error
   {:execution-id #uuid "96769ec5-afdd-4dc9-93c4-de80d610ded8",
    :stage :leave,
    :interceptor :wkok.openai-clojure.sse/perform-sse-capable-request,
    :type java.net.ConnectException,
    :exception #error {
    :cause nil
    :via
    [{:type java.net.ConnectException
      :message nil
      :at [jdk.internal.net.http.HttpClientImpl send "HttpClientImpl.java" 573]}
     {:type java.net.ConnectException
      :message nil
      :at [jdk.internal.net.http.common.Utils toConnectException "Utils.java" 1047]}
     {:type java.nio.channels.UnresolvedAddressException
      :message nil
      :at [sun.nio.ch.Net checkAddress "Net.java" 149]}]
    :trace
   ```