### PR TITLE
Update claude env

### DIFF
--- a/resources/env.edn
+++ b/resources/env.edn
@@ -53,6 +53,7 @@
                     :mistral-embed
                     :open-codestral-mamba :codestral-latest}}
    :claude       {:api-endpoint #or [#env "CLAUDE_API_ENDPOINT" "https://api.anthropic.com/v1"]
+                  :api-key [#env "ANTHROPIC_API_KEY"]
                   :model-params          {:model       :claude-3-5-haiku-latest
                                           ;; max tokens is required parameter when
                                           ;; making a call to Claude, use this as default

--- a/resources/env.edn
+++ b/resources/env.edn
@@ -53,14 +53,16 @@
                     :mistral-embed
                     :open-codestral-mamba :codestral-latest}}
    :claude       {:api-endpoint #or [#env "CLAUDE_API_ENDPOINT" "https://api.anthropic.com/v1"]
-                  :model-params          {:model       :claude-3-haiku-20240307
+                  :model-params          {:model       :claude-3-5-haiku-latest
                                           ;; max tokens is required parameter when
                                           ;; making a call to Claude, use this as default
                                           :max_tokens  500
                                           :temperature 0.6}
                   :chat-fn               bosquet.llm.claude/messages
                   :model-names
-                  #{:claude-3-5-sonnet-20240620 :claude-3-opus-20240229 :claude-3-sonnet-20240229
+                  #{:claude-3-opus-latest :claude-3-5-haiku-latest :claude-3-5-sonnet-latest
+                    :claude-3-5-haiku-20241022 :claude-3-5-sonnet-20241022
+                    :claude-3-5-sonnet-20240620 :claude-3-opus-20240229 :claude-3-sonnet-20240229
                     :claude-3-haiku-20240307}}
    :cohere       {:model-params {:model       :command
                                  :temperature 0}


### PR DESCRIPTION
- Updates to the latest [model versions](https://docs.anthropic.com/en/docs/about-claude/models).
- Reads api key from the usual environment variable, so that claude works with bosquet similarly as chatgpt does (automatically works even without setting secrets.edn for people who have their environment set up according to [the anthropic docs](https://docs.anthropic.com/en/docs/initial-setup#set-your-api-key)).