### PR TITLE
upgrade deps

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,29 +1,29 @@
 {:paths   ["src" "resources"]
  :deps    {org.clojure/clojure                           {:mvn/version "1.12.0"}
            io.github.zmedelis/hfds-clj                   {:mvn/version "2023.12.11"}
-           com.wsscode/pathom3                           {:mvn/version "2023.08.22-alpha"}
-           net.clojars.wkok/openai-clojure               {:mvn/version "0.21.0"}
-           com.taoensso/timbre                           {:mvn/version "6.5.0"}
+           com.wsscode/pathom3                           {:mvn/version "2024.11.23-alpha"}
+           net.clojars.wkok/openai-clojure               {:mvn/version "0.22.0"}
+           com.taoensso/timbre                           {:mvn/version "6.6.1"}
            com.knuddels/jtokkit                          {:mvn/version "1.1.0"}
            http-kit/http-kit                             {:mvn/version "2.8.0"}
            hato/hato                                     {:mvn/version "1.0.0"}
-           metosin/jsonista                              {:mvn/version "0.3.10"}
+           metosin/jsonista                              {:mvn/version "0.3.13"}
            org.clojars.danielsz/cohere                   {:mvn/version "1.0.0"}
            aero/aero                                     {:mvn/version "1.1.6"}
            org.clojure/core.cache                        {:mvn/version "1.1.234"}
-           org.apache.commons/commons-text               {:mvn/version "1.12.0"}
-           me.flowthing/pp                               {:mvn/version "2024-01-04.60"}
-           org.apache.tika/tika-core                     {:mvn/version "2.9.2"}
+           org.apache.commons/commons-text               {:mvn/version "1.13.0"}
+           me.flowthing/pp                               {:mvn/version "2024-11-13.77"}
+           org.apache.tika/tika-core                     {:mvn/version "3.0.0"}
            org.apache.tika/tika-parser-html-commons      {:mvn/version "2.9.2"}
-           org.apache.tika/tika-parsers-standard-package {:mvn/version "2.9.2"}
-           org.apache.opennlp/opennlp-tools              {:mvn/version "2.4.0"}
+           org.apache.tika/tika-parsers-standard-package {:mvn/version "3.0.0"}
+           org.apache.opennlp/opennlp-tools              {:mvn/version "2.5.2"}
            org.clojure/tools.cli                         {:mvn/version "1.1.230"}
            com.fzakaria/slf4j-timbre                     {:mvn/version "0.4.1"}
-           org.clojure/core.async                        {:mvn/version "1.6.681"}
+           org.clojure/core.async                        {:mvn/version "1.7.701"}
            selmer/selmer                                 {:mvn/version "1.12.61"}}
  :aliases {:dev        {:extra-paths ["dev" "notebook"]
-                        :extra-deps  {io.github.nextjournal/clerk          {:mvn/version "0.16.1016"}
-                                      djblue/portal                        {:mvn/version "0.57.3"}
+                        :extra-deps  {io.github.nextjournal/clerk          {:mvn/version "0.17.1102"}
+                                      djblue/portal                        {:mvn/version "0.58.5"}
                                       com.github.clj-easy/graal-build-time {:mvn/version "1.0.5"}}}
            :neil       {:project {:name    io.github.zmedelis/bosquet
                                   :version "2024.08.08"}}
@@ -35,8 +35,8 @@
            :kaocha     {:main-opts   ["-m" "kaocha.runner"]
                         :extra-paths ["test"]
                         :extra-deps  {lambdaisland/kaocha {:mvn/version "1.91.1392"}}}
-           :build      {:deps       {io.github.clojure/tools.build {:git/tag "v0.10.5"
-                                                                    :git/sha "2a21b7a"}
+           :build      {:deps       {io.github.clojure/tools.build {:git/tag "v0.10.6"
+                                                                    :git/sha "52cf7d6"}
                                      slipset/deps-deploy           {:mvn/version "0.2.2"}}
                         :ns-default build}
            :ns-default build}}


### PR DESCRIPTION
Mainly because I had some issues with the old version of timbre which seems to be fixed in current.
Seems to work just fine in my experience. All tests pass (except cohere, which I am unable to test).