### PR TITLE
Adds native tool support for chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 [![Clojars Project](https://img.shields.io/clojars/v/io.github.zmedelis/bosquet.svg)](https://clojars.org/io.github.zmedelis/bosquet)
 
-# LLMOps for Large Language Model-based applications 
+# LLMOps for Large Language Model-based applications
 
 Bosquet is on a mission to make building AI applications simple. All nontrivial AI applications need to work with prompt templates that quickly grow in complexity, limited LLM context windows require memory management, and agents are needed for AI applications to interact with the outside world.
 
 Bosquet provides instruments to work with those AI application concepts:
-* LLM and Tool service management
-* Prompt templating via integration with the excellent [Selmer](https://github.com/yogthos/Selmer) templating library
-* Prompt chaining and composition via a powerful [Pathom](https://pathom3.wsscode.com/) graph processing machine
-* Agent and tools definition abstractions for the interactions with external APIs
-* LLM memory handling
-* Other instruments like call response caching (see documentation)
+
+- LLM and Tool service management
+- Prompt templating via integration with the excellent [Selmer](https://github.com/yogthos/Selmer) templating library
+- Prompt chaining and composition via a powerful [Pathom](https://pathom3.wsscode.com/) graph processing machine
+- Agent and tools definition abstractions for the interactions with external APIs
+- LLM memory handling
+- Other instruments like call response caching (see documentation)
 
 ## Documentation
 
@@ -27,16 +28,19 @@ Command line interface demo
 [![CLI](https://img.youtube.com/vi/ywlNGiD9gCg/0.jpg)](https://www.youtube.com/watch?v=ywlNGiD9gCg)
 
 Run the following command to get CLI options
+
 ```
 clojure -M -m bosquet.cli
 ```
 
 Set the default model with
+
 ```
 clojure -M -m bosquet.cli llms set --service openai --temperature 0 --model gpt-4o
 ```
 
 Do not forget to set the API KEY for your service (change 'openai' to a different name if needed)
+
 ```
 clojure -M -m bosquet.cli keys set openai
 ```
@@ -46,7 +50,9 @@ With that set, you can run generations:
 ```
 clojure -M -m bosquet.cli "2+{{x}}="
 ```
+
 Or using files
+
 ```
 clojure -M -m bosquet.cli -p demo/play-writer-prompt.edn -d demo/play-writer-data.edn
 ```
@@ -63,9 +69,7 @@ Simple prompt completion can be done like this.
 "When you were 6, your sister was half your age, which means she was 6 / 2 = 3 years old.\nSince then, there is a constant age difference of 3 years between you and your sister.\nNow that you are 70, your sister would be 70 - 6 = 64 years old."}
 ```
 
-
 ### Completion from the prompt map
-
 
 ```clojure
 (require '[bosquet.llm :as llm])
@@ -97,7 +101,7 @@ Simple prompt completion can be done like this.
 
 ### Chat
 
-``` clojure
+```clojure
 (require '[bosquet.llm.wkk :as wkk])
 (generate
     [[:system "You are an amazing writer."]
@@ -132,3 +136,72 @@ Simple prompt completion can be done like this.
 ```
 
 Generation returns `:bosquet/conversation` listing full chat with generated parts filled in, and `:bosquet/completions` containing only generated data
+
+### Tools
+
+Supports tools for chats for openai and ollama based models similar to how ragtacts does it
+
+```clojure
+(require '[bosquet.llm.generator :refer [generate llm]])
+(require 'bosquet.llm.wkk :as wkk)
+
+;define a tool for the weather station
+(defn ^{:desc "Get the current weather in a given location"} get-current-weather
+    [^{:type "string" :desc "The city, e.g. San Francisco"} location]
+    (prn (format "Applying  get-current-weather for location %s" location))
+    (case (str/lower-case location)
+      "tokyo" {:location "Tokyo" :temperature "10" :unit "fahrenheit"}
+      "san francisco" {:location "San Francisco" :temperature "72" :unit "fahrenheit"}
+      "paris" {:location "Paris" :temperature "22" :unit "fahrenheit"}
+      {:location location :temperature "unknown"}))
+
+(generate [[:system "You are a weather reporter"]
+           [:user "What is the temperature in San Francisco"]
+           [:assistant (llm wkk/ollama wkk/model-params
+                       {:model "llama3.2:b" wkk/tools [#'get-current-weather]}
+                        wkk/var-name :weather-report)]])
+=>
+#:bosquet{:conversation
+          [[:system "You are a weather reporter"]
+           [:user "What is the temperature in San Francisco"]
+           [:assistant
+            "According to the current weather conditions, the temperature in San Francisco is 72°F (Fahrenheit)."]],
+          :completions
+          {:weather-report
+           "According to the current weather conditions, the temperature in San Francisco is 72°F (Fahrenheit)."},
+          :usage
+          {:weather-report {:prompt 90, :completion 21, :total 111},
+           :bosquet/total {:prompt 90, :completion 21, :total 111}},
+          :time 3034}
+
+;;Write some calculator functions
+(defn ^{:desc "add 'x' and 'y'"} add
+    [^{:type "number" :desc "First number to add"} x
+     ^{:type "number" :desc "Second number to add"} y]
+    (prn (format "Applying add for %s %s" x y))
+    (+ (if (number? x)  x (Float/parseFloat x) )
+       (if (number? y)  y (Float/parseFloat y) )))
+
+(defn ^{:desc "subtract 'y' from 'x'"} sub
+    [^{:type "number" :desc "Number to subtract from"} x
+     ^{:type "number" :desc "Number to subtract"} y]
+  (prn (format "Applying sub %s %s" x y))
+  (- (if (number? x)  x (Float/parseFloat x) )
+       (if (number? y)  y (Float/parseFloat y) )))
+
+(generate [[:system "You are a math wizard"]
+             [:user "What is 2 + 2 - 3"]
+             [:assistant (llm wkk/openai
+                          wkk/model-params {wkk/tools [#'add #'sub]}
+                          wkk/var-name :answer)]])
+=>
+#:bosquet{:conversation
+          [[:system "You are a math wizard"]
+           [:user "What is 2 + 2 - 3"]
+           [:assistant "2 + 2 - 3 equals 1"]],
+          :completions {:answer "2 + 2 - 3 equals 1"},
+          :usage
+          {:answer {:prompt 181, :completion 12, :total 193},
+           :bosquet/total {:prompt 181, :completion 12, :total 193}},
+          :time 1749}
+```

--- a/src/bosquet/llm/generator.clj
+++ b/src/bosquet/llm/generator.clj
@@ -613,4 +613,14 @@
             "provide me with​ a) average distance b) max distance c) min distance"]]
     [:assistant (llm :mistral-small
                      wkk/var-name :analysis)]])
+
+   (generate
+            [[:system "You are a math wizard"]
+             [:user "What is 2 + 2 - 3"]
+             [:assistant (llm wkk/openai wkk/model-params {wkk/tools [#'bosquet.llm.tools/add #'bosquet.llm.tools/sub]} wkk/var-name :answer)]])
+
+   (generate
+            [[:system "You are a weather reporter"]
+             [:user "What is the temperature in San Francisco"]
+             [:assistant (llm wkk/ollama wkk/model-params {:model "llama3.2:3b" wkk/tools [#'bosquet.llm.tools/get-current-weather]} wkk/var-name :weather-report)]])
   #__)

--- a/src/bosquet/llm/oai_shaped_llm.clj
+++ b/src/bosquet/llm/oai_shaped_llm.clj
@@ -16,6 +16,7 @@
    (-> params
        (u/mergex defaults params)
        (dissoc wkk/model-params)
+       (dissoc wkk/tools)
        (merge (wkk/model-params params)))))
 
 ;; ## ChatML

--- a/src/bosquet/llm/tools.clj
+++ b/src/bosquet/llm/tools.clj
@@ -1,0 +1,102 @@
+(ns bosquet.llm.tools
+  (:require [clojure.string :as str]
+            [cheshire.core :as json]
+            [bosquet.llm.wkk :as wkk]
+            [taoensso.timbre :as timbre]))
+
+(defn tool->function [tool-var]
+  (let [fn-meta (meta tool-var)
+        args (into {}
+                   (map
+                    (fn [arg]
+                      (let [arg-meta (meta arg)]
+                        [(keyword arg) {:type (:type arg-meta)
+                                        :description (:desc arg-meta)}]))
+                    (first (:arglists (meta tool-var)))))]
+    {:type "function"
+     :function {:name (name (:name fn-meta))
+                :ns (str (:ns fn-meta))
+                :description (:desc fn-meta)
+                :parameters {:type "object"
+                             :properties args
+                             :required (map name (first (:arglists fn-meta)))}}}))
+
+(defn- select-tool-by-name [tools function]
+  (first (filter #(= (:name function) (name (:name (meta %)))) tools)))
+
+(defn- parse-arguments [model-engine result]
+  (let [result (condp = model-engine
+                 wkk/ollama (:message result)
+                 wkk/openai (-> result :choices first :message))] 
+    (update result :tool_calls
+          #(map (fn [tool-call]
+                  (update-in tool-call [:function :arguments]
+                             (fn [arguments]
+                               (if (string? arguments)
+                                 (json/parse-string arguments true) 
+                                 arguments)))) %)) ))
+
+(defn- apply-fn [tool function]
+  (let [args (first (:arglists (meta tool)))]
+    (apply tool (map #(get (:arguments function) (keyword %)) args))))
+
+(defn- apply-tool
+  [tools {:keys [id function]}]
+  (let [tool (select-tool-by-name tools function)]
+    {:id id
+     :function function
+     :result (when tool
+               (apply-fn tool function))} ))
+
+(defn- tool-result-formatter
+  [model-engine result tool-results]
+  (let [tool-results (map #(condp = model-engine
+                              wkk/ollama {:role "tool" :content (json/generate-string (:result %))}
+                              wkk/openai {:role "tool" :content (json/generate-string (:result %)) :tool_call_id (:id %)}) tool-results)]
+    (condp = model-engine
+      wkk/ollama tool-results
+      wkk/openai (concat [{:role "assistant" :tool_calls (-> result :choices first :message :tool_calls)}] tool-results))))
+
+(defn apply-tools
+  [result engine params tools generator]
+  (timbre/infof "Applying tools %d for engine %s" (count tools) engine)
+  (if (not-empty tools)
+    (let [parsed-result (parse-arguments engine result)
+          fn-results (->> (:tool_calls parsed-result)
+                          (map #(apply-tool tools %)))
+          tool-messages (tool-result-formatter engine result fn-results)
+          messages (concat (vec (:messages params)) tool-messages)]
+      (timbre/debug messages)
+      (if (seq? tool-messages)
+        (generator (-> params 
+                       (dissoc wkk/tools) 
+                       (assoc :messages messages)))
+        result))
+    result))
+
+(comment 
+  (defn ^{:desc "Get the current weather in a given location"} get-current-weather
+    [^{:type "string" :desc "The city, e.g. San Francisco"} location]
+    (timbre/infof "Applying get-current-weather for location %s" location)
+    (case (str/lower-case location)
+      "tokyo" {:location "Tokyo" :temperature "10" :unit "fahrenheit"}
+      "san francisco" {:location "San Francisco" :temperature "72" :unit "fahrenheit"}
+      "paris" {:location "Paris" :temperature "22" :unit "fahrenheit"}
+      {:location location :temperature "unknown"}))
+
+  (defn ^{:desc "add 'x' and 'y'"} add
+    [^{:type "number" :desc "First number to add"} x
+     ^{:type "number" :desc "Second number to add"} y]
+    (timbre/infof "Applying add for location %s %s" x y)
+    (+ (if (number? x)  x (Float/parseFloat x) )
+       (if (number? y)  y (Float/parseFloat y) )))
+
+(defn ^{:desc "subtract 'y' from 'x'"} sub
+    [^{:type "number" :desc "Number to subtract from"} x
+     ^{:type "number" :desc "Number to subtract"} y]
+  (timbre/infof "Applying sub for location %s %s" x y)
+  (- (if (number? x)  x (Float/parseFloat x) )
+       (if (number? y)  y (Float/parseFloat y) )))
+
+  (tool->function #'get-current-weather)
+  (tool->function #'add))

--- a/src/bosquet/llm/wkk.clj
+++ b/src/bosquet/llm/wkk.clj
@@ -22,6 +22,8 @@
 
 (def mistral :mistral)
 
+(def ollama :ollama)
+
 (def model-params :llm/model-params)
 (def chat-fn :chat-fn)
 (def complete-fn :complete-fn)
@@ -44,3 +46,6 @@
 
 (def fun-args
   :fun/args)
+
+(def tools
+  :llm/tools)


### PR DESCRIPTION
All openai models and some ollama models support calling native clojure functions as tools by passing in a :tools key in the model params 

Currently works for chat generation only.

Thanks for functions borrowed from [ragtacts](https://github.com/constacts/ragtacts)