### PR TITLE
Add provider failover/fallback system with circuit breaker support

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -42,3 +42,4 @@
                                      slipset/deps-deploy           {:mvn/version "0.2.2"}}
                         :ns-default build}
            :ns-default build}}
+

--- a/notebook/named_entity_processing.clj
+++ b/notebook/named_entity_processing.clj
@@ -501,8 +501,22 @@ Oct. 14: Jupiter and the Moon rise near each other in the middle of the night an
 (def non-astronomy-text "China says Taiwan spoils atmosphere for talks")
 
 ;; Memory used:
-{:nextjournal.clerk/visibility {:code :show :result :show}}
+{:nextjournal.clerk/visibility {:code :show :result :hide}}
 (def memory-1 (sm-recaller {r/memory-content :input} non-astronomy-text))
+
+^{:nextjournal.clerk/visibility {:code :hide :result :show}}
+(clerk/html
+  [:div.block.p-6.bg-white.border.border-gray-200.rounded-lg.shadow.dark:bg-gray-800.dark:border-gray-700
+   [:div.mb-4 [:strong "Retrieved Examples from Memory:"]]
+   [:div.space-y-3
+    (for [example memory-1]
+      [:div.border.border-gray-300.rounded.p-3.bg-gray-50
+       [:div.mb-2
+        [:span.font-semibold.text-gray-700 "Input: "]
+        [:span.font-mono.text-sm (:input example)]]
+       [:div
+        [:span.font-semibold.text-gray-700 "Output: "]
+        [:span.font-mono.text-sm (:output example)]]])]])
 
 ^{:nextjournal.clerk/visibility {:result :hide :code :show}}
 (def negative-test
@@ -528,8 +542,26 @@ Oct. 14: Jupiter and the Moon rise near each other in the middle of the night an
   "Jupiter and the Moon rise near each other in the middle of the night. Comets are visible this month. The comet appears in May.")
 
 ;; Memory used:
-{:nextjournal.clerk/visibility {:code :show :result :show}}
+{:nextjournal.clerk/visibility {:code :show :result :hide}}
 (def memory-2 (sm-recaller {r/memory-content :input} gpt-ner-test-text))
+
+^{:nextjournal.clerk/visibility {:code :hide :result :show}}
+(clerk/html
+  [:div.block.p-6.bg-white.border.border-gray-200.rounded-lg.shadow.dark:bg-gray-800.dark:border-gray-700
+   [:div.mb-4 [:strong "Retrieved Examples from Memory:"]]
+   [:div.space-y-3
+    (concat
+     (for [example (take 5 memory-2)]
+       [:div.border.border-gray-300.rounded.p-3.bg-gray-50
+        [:div.mb-2
+         [:span.font-semibold.text-gray-700 "Input: "]
+         [:span.font-mono.text-sm (:input example)]]
+        [:div
+         [:span.font-semibold.text-gray-700 "Output: "]
+         [:span.font-mono.text-sm (:output example)]]])
+     (when (> (count memory-2) 5)
+       [[:div.text-center.text-gray-500.italic.py-2
+         (str "... and " (- (count memory-2) 5) " more examples")]]))]])
 
 ^{:nextjournal.clerk/visibility {:result :hide :code :show}}
 (def gpt-ner-extraction

--- a/resources/env.edn
+++ b/resources/env.edn
@@ -133,7 +133,19 @@
    :qdrant {:api-endpoint #or [#env "QDRANT_API_ENDPOINT" "http://localhost:6333"]
             :on-disk      true
             :size         1536
-            :distance     :Dot}}
+            :distance     :Dot}
+
+   ;; ########
+   ;; Resilience defaults
+   ;; ########
+
+   :resilience-defaults
+   {:retry          {:max-attempts 3
+                     :backoff-ms   1000}
+    :circuit-breaker {:failure-threshold 50
+                      :min-calls         5
+                      :timeout-ms        60000
+                      :success-threshold 2}}}
 
   ;; config.edn contains local settings for the LLM services, tools,
   ;; and other components, values in this file will override the above

--- a/src/bosquet/llm/generator.clj
+++ b/src/bosquet/llm/generator.clj
@@ -106,6 +106,29 @@
                            (chat-fn params))]
       (update-in result [wkk/content :content] format-fn))))
 
+(defn- do-complete-call
+  [llm-config
+   {llm-impl     wkk/service
+    model-params wkk/model-params
+    use-cache    wkk/cache
+    :as          properties}
+   prompt]
+  (when-let [complete-impl (get-in llm-config [llm-impl wkk/complete-fn])]
+    (let [format-fn      (partial converter/coerce (wkk/output-format properties))
+          service-config (dissoc (llm-impl llm-config)
+                                 wkk/complete-fn wkk/chat-fn wkk/embed-fn)
+          complete-fn    (partial (if (symbol? complete-impl)
+                                    (requiring-resolve complete-impl)
+                                    complete-impl)
+                                  service-config)
+          params         (merge
+                          (get-in llm-config [llm-impl :model-params])
+                          (assoc model-params :prompt prompt))
+          result         (if use-cache
+                           (cache/lookup-or-call complete-fn params)
+                           (complete-fn params))]
+      (update-in result [wkk/content :completion] format-fn))))
+
 (defn call-llm
   "Make a call to the LLM service.
   - `llm-config` provides a map containing LLM service configurations, the
@@ -119,6 +142,19 @@
     (resilience/with-fallback do-llm-call resilience-config llm-config messages)
     (or (do-llm-call llm-config properties messages)
         (timbre/warnf "Generation instruction does not contain AI gen function spec"))))
+
+(defn call-complete
+  "Make a completion call to the LLM service.
+  - `llm-config` provides a map containing LLM service configurations
+  - `properties` providing model parameters and other details
+  - `prompt` contains the text prompt to be supplied to LLM."
+  [llm-config
+   {resilience-config wkk/resilience :as properties}
+   prompt]
+  (if resilience-config
+    (resilience/with-fallback do-complete-call resilience-config llm-config prompt)
+    (or (do-complete-call llm-config properties prompt)
+        (timbre/warnf "Generation instruction does not contain completion function spec"))))
 
 (def conversation
   "Result map key holding full chat conversation including generated parts"

--- a/src/bosquet/llm/generator.clj
+++ b/src/bosquet/llm/generator.clj
@@ -4,6 +4,7 @@
    [bosquet.db.cache :as cache]
    [bosquet.env :as env]
    [bosquet.llm.gen-data :as gd]
+   [bosquet.llm.resilience :as resilience]
    [bosquet.llm.wkk :as wkk]
    [bosquet.template.selmer :as selmer]
    [bosquet.utils :as u]
@@ -80,19 +81,14 @@
                  content)})
    messages))
 
-(defn call-llm
-  "Make a call to the LLM service.
-  - `llm-config` provides a map containing LLM service configurations, the
-     LLM to call is specified in
-  - `properties` providing model parameters and other details of LLM invocation
-  - `messages` contains the context/prompt to be supplied to LLM."
+(defn- do-llm-call
   [llm-config
    {llm-impl     wkk/service
     model-params wkk/model-params
     use-cache    wkk/cache
     :as          properties}
    messages]
-  (if-let [chat-impl (get-in llm-config [llm-impl wkk/chat-fn])]
+  (when-let [chat-impl (get-in llm-config [llm-impl wkk/chat-fn])]
     (let [format-fn      (partial converter/coerce (wkk/output-format properties))
           service-config (dissoc (llm-impl llm-config)
                                  wkk/complete-fn wkk/chat-fn wkk/embed-fn)
@@ -105,12 +101,24 @@
           params         (merge
                           (get-in llm-config [llm-impl :model-params])
                           (assoc model-params :messages (->chatml messages)))
-
           result         (if use-cache
                            (cache/lookup-or-call chat-fn params)
                            (chat-fn params))]
-      (update-in result [wkk/content :content] format-fn))
-    (timbre/warnf "Generation instruction does not contain AI gen function spec")))
+      (update-in result [wkk/content :content] format-fn))))
+
+(defn call-llm
+  "Make a call to the LLM service.
+  - `llm-config` provides a map containing LLM service configurations, the
+     LLM to call is specified in
+  - `properties` providing model parameters and other details of LLM invocation
+  - `messages` contains the context/prompt to be supplied to LLM."
+  [llm-config
+   {resilience-config wkk/resilience :as properties}
+   messages]
+  (if resilience-config
+    (resilience/with-fallback do-llm-call resilience-config llm-config messages)
+    (or (do-llm-call llm-config properties messages)
+        (timbre/warnf "Generation instruction does not contain AI gen function spec"))))
 
 (def conversation
   "Result map key holding full chat conversation including generated parts"

--- a/src/bosquet/llm/http.clj
+++ b/src/bosquet/llm/http.clj
@@ -13,6 +13,21 @@
    (System/setProperty "https.proxyHost" host)
    (System/setProperty "https.proxyPort" (str port))))
 
+(defn- classify-error [status]
+  (cond
+    (= status 429)      :rate-limit
+    (= status 503)      :service-unavailable
+    (= status 502)      :bad-gateway
+    (= status 504)      :gateway-timeout
+    (#{500} status)     :server-error
+    (#{400 422} status) :bad-request
+    (#{401 403} status) :auth-error
+    (#{404} status)     :not-found
+    :else               :unknown))
+
+(def retryable-errors #{:rate-limit :service-unavailable :bad-gateway :gateway-timeout})
+(def recoverable-errors #{:server-error :rate-limit :service-unavailable})
+
 (defn post
   ([url params] (post url nil params))
   ([url http-opts params]
@@ -23,14 +38,19 @@
                             :body         (->> params u/snake-case u/write-json)}
                            http-opts)
            response (client/post url request)]
-       (-> response :body (u/read-json)))
+       (-> response :body u/read-json))
      (catch Exception e
-       (.printStackTrace e)
-       (let [{:keys [body status]}   (ex-data e)
-             {:keys [message error]} (u/read-json body)]
-         (timbre/error "Call failed")
-         (timbre/errorf "- HTTP status '%s'" status)
-         (timbre/errorf "- Error message '%s'" (or message error)))))))
+       (let [{:keys [body status]} (ex-data e)
+             {:keys [message error]} (when body (u/read-json body))
+             error-type (classify-error status)]
+         (timbre/errorf "HTTP %s: %s" status (or message error))
+         (throw (ex-info (str "LLM API error: " (or message error "Unknown error"))
+                         {:type         error-type
+                          :status       status
+                          :message      (or message error)
+                          :retryable?   (retryable-errors error-type)
+                          :recoverable? (recoverable-errors error-type)}
+                         e)))))))
 
 (def resilient-post*
   (cb/wrap (fn [& args]
@@ -39,4 +59,3 @@
 
 (defn resilient-post [& args]
   (apply resilient-post* args))
-

--- a/src/bosquet/llm/resilience.clj
+++ b/src/bosquet/llm/resilience.clj
@@ -1,0 +1,77 @@
+(ns bosquet.llm.resilience
+  (:require
+   [bosquet.llm.wkk :as wkk]
+   [net.modulolotus.truegrit.circuit-breaker :as cb]
+   [taoensso.timbre :as timbre]))
+
+(defonce ^:private circuit-breakers (atom {}))
+
+(defn- get-or-create-cb 
+  [provider-key 
+   config]
+  (or (get @circuit-breakers provider-key)
+      (let [new-cb (cb/circuit-breaker
+                    (name provider-key)
+                    {:failure-rate-threshold                       (:failure-threshold config 50)
+                     :minimum-number-of-calls                      (:min-calls config 5)
+                     :wait-duration-in-open-state                  (:timeout-ms config 60000)
+                     :permitted-number-of-calls-in-half-open-state (:success-threshold config 2)})]
+        (swap! circuit-breakers assoc provider-key new-cb)
+        new-cb)))
+
+(defn- sleep-backoff 
+  [attempt 
+   base-ms]
+  (Thread/sleep (long (min (* base-ms (Math/pow 2 attempt)) 30000))))
+
+(defn with-retry
+  [f {:keys [max-attempts backoff-ms] :or {max-attempts 3 backoff-ms 1000}}]
+  (loop [attempt 0]
+    (let [result (try
+                   {:success (f)}
+                   (catch Exception e
+                     {:error e :retryable? (:retryable? (ex-data e))}))]
+      (cond
+        (:success result)
+        (:success result)
+
+        (and (:retryable? result) (< attempt (dec max-attempts)))
+        (do
+          (timbre/infof "Retry %d/%d" (inc attempt) max-attempts)
+          (sleep-backoff attempt backoff-ms)
+          (recur (inc attempt)))
+
+        :else
+        (throw (:error result))))))
+
+(defn- try-provider 
+  [call-fn 
+   provider 
+   llm-config 
+   messages 
+   cb-config 
+   retry-config]
+  (let [provider-key (wkk/service provider)
+        wrapped (cb/wrap (fn []
+                           (with-retry #(call-fn llm-config 
+                                                 provider 
+                                                 messages)  
+                                       retry-config))
+                         (get-or-create-cb provider-key cb-config))]
+    (wrapped)))
+
+(defn with-fallback
+  [call-fn {:keys [primary fallbacks retry circuit-breaker]} llm-config messages]
+  (loop [[provider & remaining] (cons primary fallbacks)
+         last-error nil]
+    (if provider
+      (let [result (try
+                     {:success (try-provider call-fn provider llm-config messages circuit-breaker retry)}
+                     (catch Exception e
+                       (timbre/warnf "Provider %s failed: %s" (wkk/service provider) (.getMessage e))
+                       {:error e :recoverable? (:recoverable? (ex-data e))}))]
+        (cond
+          (:success result) (:success result)
+          (:recoverable? result) (recur remaining (:error result))
+          :else (throw (:error result))))
+      (throw (ex-info "All providers failed" {:type :all-providers-failed} last-error)))))

--- a/src/bosquet/llm/resilience.clj
+++ b/src/bosquet/llm/resilience.clj
@@ -6,6 +6,11 @@
 
 (defonce ^:private circuit-breakers (atom {}))
 
+(defn reset-circuit-breakers!
+  "Reset all circuit breakers. Useful for testing."
+  []
+  (reset! circuit-breakers {}))
+
 (defn- get-or-create-cb 
   [provider-key 
    config]

--- a/src/bosquet/llm/wkk.clj
+++ b/src/bosquet/llm/wkk.clj
@@ -46,3 +46,5 @@
 
 (def tools
   :llm/tools)
+
+(def resilience :llm/resilience)

--- a/test/bosquet/llm/resilience_test.clj
+++ b/test/bosquet/llm/resilience_test.clj
@@ -1,0 +1,102 @@
+(ns bosquet.llm.resilience-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [bosquet.llm.resilience :as resilience]
+   [bosquet.llm.wkk :as wkk]))
+
+(deftest retry-test
+  (testing "retries on retryable error"
+    (let [call-count (atom 0)]
+      (is (= :success
+             (resilience/with-retry
+               (fn []
+                 (swap! call-count inc)
+                 (if (< @call-count 3)
+                   (throw (ex-info "Rate limited" {:retryable? true}))
+                   :success))
+               {:max-attempts 3 :backoff-ms 10})))
+      (is (= 3 @call-count))))
+
+  (testing "fails immediately on non-retryable error"
+    (let [call-count (atom 0)]
+      (is (thrown? Exception
+                   (resilience/with-retry
+                     (fn []
+                       (swap! call-count inc)
+                       (throw (ex-info "Auth error" {:retryable? false})))
+                     {:max-attempts 3})))
+      (is (= 1 @call-count))))
+
+  (testing "exhausts max attempts on persistent retryable error"
+    (let [call-count (atom 0)]
+      (is (thrown? Exception
+                   (resilience/with-retry
+                     (fn []
+                       (swap! call-count inc)
+                       (throw (ex-info "Rate limited" {:retryable? true})))
+                     {:max-attempts 3 :backoff-ms 10})))
+      (is (= 3 @call-count)))))
+
+(deftest fallback-test
+  (testing "falls back to secondary provider"
+    (let [calls (atom [])]
+      (is (= {:result "success from claude"}
+             (resilience/with-fallback
+               (fn [_ provider _]
+                 (swap! calls conj (wkk/service provider))
+                 (if (= :openai (wkk/service provider))
+                   (throw (ex-info "Service down" {:recoverable? true}))
+                   {:result "success from claude"}))
+               {:primary {wkk/service :openai}
+                :fallbacks [{wkk/service :claude}]
+                :retry {:max-attempts 1}
+                :circuit-breaker {}}
+               {}
+               [])))
+      (is (= [:openai :claude] @calls))))
+
+  (testing "does not fall back on non-recoverable error"
+    (let [calls (atom [])]
+      (is (thrown? Exception
+                   (resilience/with-fallback
+                     (fn [_ provider _]
+                       (swap! calls conj (wkk/service provider))
+                       (throw (ex-info "Bad request" {:recoverable? false})))
+                     {:primary {wkk/service :openai}
+                      :fallbacks [{wkk/service :claude}]
+                      :retry {:max-attempts 1}
+                      :circuit-breaker {}}
+                     {}
+                     [])))
+      (is (= [:openai] @calls))))
+
+  (testing "succeeds with primary provider"
+    (let [calls (atom [])]
+      (is (= {:result "success from openai"}
+             (resilience/with-fallback
+               (fn [_ provider _]
+                 (swap! calls conj (wkk/service provider))
+                 {:result "success from openai"})
+               {:primary {wkk/service :openai}
+                :fallbacks [{wkk/service :claude}]
+                :retry {:max-attempts 1}
+                :circuit-breaker {}}
+               {}
+               [])))
+      (is (= [:openai] @calls))))
+
+  (testing "throws when all providers fail"
+    (let [calls (atom [])]
+      (is (thrown-with-msg? Exception #"All providers failed"
+                            (resilience/with-fallback
+                              (fn [_ provider _]
+                                (swap! calls conj (wkk/service provider))
+                                (throw (ex-info "Service down" {:recoverable? true})))
+                              {:primary {wkk/service :openai}
+                               :fallbacks [{wkk/service :claude}
+                                           {wkk/service :mistral}]
+                               :retry {:max-attempts 1}
+                               :circuit-breaker {}}
+                              {}
+                              [])))
+      (is (= [:openai :claude :mistral] @calls)))))

--- a/test/bosquet/llm/resilience_test.clj
+++ b/test/bosquet/llm/resilience_test.clj
@@ -1,8 +1,10 @@
 (ns bosquet.llm.resilience-test
   (:require
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [bosquet.llm.resilience :as resilience]
    [bosquet.llm.wkk :as wkk]))
+
+(use-fixtures :each (fn [f] (resilience/reset-circuit-breakers!) (f)))
 
 (deftest retry-test
   (testing "retries on retryable error"
@@ -100,3 +102,36 @@
                               {}
                               [])))
       (is (= [:openai :claude :mistral] @calls)))))
+
+(deftest complete-fallback-test
+  (testing "completion falls back to secondary provider"
+    (let [calls (atom [])]
+      (is (= {:result "completion from mistral"}
+             (resilience/with-fallback
+               (fn [_ provider prompt]
+                 (swap! calls conj (wkk/service provider))
+                 (if (= :openai (wkk/service provider))
+                   (throw (ex-info "Service down" {:recoverable? true}))
+                   {:result "completion from mistral"}))
+               {:primary {wkk/service :openai}
+                :fallbacks [{wkk/service :mistral}]
+                :retry {:max-attempts 1}
+                :circuit-breaker {}}
+               {}
+               "Complete this: Hello")))
+      (is (= [:openai :mistral] @calls))))
+
+  (testing "completion succeeds with primary provider"
+    (let [calls (atom [])]
+      (is (= {:result "completion from openai"}
+             (resilience/with-fallback
+               (fn [_ provider prompt]
+                 (swap! calls conj (wkk/service provider))
+                 {:result "completion from openai"})
+               {:primary {wkk/service :openai}
+                :fallbacks [{wkk/service :mistral}]
+                :retry {:max-attempts 1}
+                :circuit-breaker {}}
+               {}
+               "Complete this: Hello")))
+      (is (= [:openai] @calls)))))


### PR DESCRIPTION
## Summary

  Add a declarative, data-driven provider failover/fallback system with circuit breaker support adding:

  - Provider fallback chain with configurable retry logic
  - Per-provider circuit breakers using existing `truegrit` library
  - HTTP error handling with structured error classification
  - Resilience wrapper in `call-llm` function (backwards compatible)

## Motivation

  Currently, when an LLM provider experiences downtime or rate limiting, Bosquet fail immediately. Production applications need resilience mechanisms to handle provider outages, rate limiting, and timeout issues.

## Usage

```clojure
;; Chat with resilience
  (generate [[:user "Whats is a Monad?"]]
    {wkk/resilience
     {:primary {:llm/service :openai :model :gpt-4o-mini}
      :fallbacks [{:llm/service :claude :model :claude-3-5-haiku-latest}]
      :retry {:max-attempts 3 :backoff-ms 1000}
      :circuit-breaker {:failure-threshold 5 :timeout-ms 60000}}})

;; Completions with resilience
  (call-complete env/config
    {wkk/service :openai
     wkk/model-params {:model :gpt-3.5-turbo-instruct}
     wkk/resilience {:primary {wkk/service :openai}
                     :fallbacks [{wkk/service :mistral}]
                     :retry {:max-attempts 3}}}
    "Complete this sentence: The quick brown fox")
  ```

---------------------------------
Relates to issue https://github.com/zmedelis/bosquet/issues/81